### PR TITLE
use cjk-gs-support instead of modified lnsysfnt.sh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "jfontmaps"]
 	path = jfontmaps
 	url = git@github.com:texjporg/jfontmaps.git
+[submodule "cjk-gs-support"]
+	path = cjk-gs-support
+	url = git@github.com:texjporg/cjk-gs-support.git

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ ${BIBUNSHOAPP}:
 
 	cp -a Patch.sh ${BIBUNSHOAPP}/Contents/Resources/
 	cp -a jfontmaps ${BIBUNSHOAPP}/Contents/Resources/
+	cp -a cjk-gs-support ${BIBUNSHOAPP}/Contents/Resources/
 
 	## replace icns file to ad-hoc our icon :D
 	cp -a artwork/bibunsho7.icns ${BIBUNSHOAPP}/Contents/Resources/applet.icns

--- a/Patch.sh
+++ b/Patch.sh
@@ -197,10 +197,12 @@ cjkgsintg(){
             ;;
     esac
     if [ ! -z "${cjkgsExtDB}" ]; then
-        cjkgsopts="--fontdef-add=${TLRESDIR}/cjk-gs-support/cjkgs-macos-${cjkgsExtDB}.dat"
+        cjkgsopts="--fontdef-add=./cjkgs-macos-${cjkgsExtDB}.dat"
     fi
 
-    ${TLRESDIR}/cjk-gs-support/cjk-gs-integrate.pl --link-texmf ${cjkgsopts} || return 1
+    pushd ${TLRESDIR}/cjk-gs-support/
+    ./cjk-gs-integrate.pl --link-texmf ${cjkgsopts} || return 1
+    popd
     return 0
 }
 

--- a/Patch.sh
+++ b/Patch.sh
@@ -196,7 +196,7 @@ cjkgsintg(){
             exit 1
             ;;
     esac
-    if [ -z "${cjkgsExtDB}" ]; then
+    if [ ! -z "${cjkgsExtDB}" ]; then
         cjkgsopts="--fontdef-add=${TLRESDIR}/cjk-gs-support/cjkgs-macos-${cjkgsExtDB}.dat"
     fi
 

--- a/Patch.sh
+++ b/Patch.sh
@@ -181,6 +181,8 @@ cjkgsintg(){
     local cjkgsExtDB=
     local cjkgsopts=
 
+    local CJKGSINTGTEMP=$(mktemp -d) # dummy directory
+
     ## See cjk-gs-support/README-macos.md in details
     case ${OSXVERSION} in
         10.[0-9]|10.[0-9].*|10.10|10.10.*)
@@ -201,8 +203,11 @@ cjkgsintg(){
     fi
 
     pushd ${TLRESDIR}/cjk-gs-support/
-    ./cjk-gs-integrate.pl --link-texmf ${cjkgsopts} || return 1
+    ./cjk-gs-integrate.pl \
+        --link-texmf --force --debug \
+        --output ${CJKGSINTGTEMP} ${cjkgsopts} || return 1
     popd
+    rm -rf ${CJKGSINTGTEMP}
     return 0
 }
 

--- a/Patch.sh
+++ b/Patch.sh
@@ -47,8 +47,11 @@ realpath() {
     return 0
 }
 
-## 
+## get app's Resources directory
 TLRESDIR=$(dirname $(realpath $0))
+
+## flag to set up OS-bundled Hiragino fonts with Resources/cjk-gs-support
+with_cjkgssupport=${with_cjkgssupport:-1} ## default: 1 (true)
 
 ## set Mac OS X version
 OSXVERSION=${OSXVERSION:-$(sw_vers -productVersion)}
@@ -100,73 +103,113 @@ mkdir -p ${HRGNMAPDIR}/
 cp -a ${TLRESDIR}/jfontmaps/maps/hiragino* ${HRGNMAPDIR}/
 
 ## modified/imported a part of lnsysfnt.sh
-HRGNLEGACYDIR=$(kpsewhich -var-value=TEXMFLOCAL)/fonts/opentype/cjk-gs-integrate # screen/hiragino-legacy
-HRGNDIR=$(kpsewhich -var-value=TEXMFLOCAL)/fonts/truetype/cjk-gs-integrate # screen/hiragino
+## https://gist.github.com/munepi/396ef67e3ad051663399
+## NOTE: This lnsysfnt() only links Mac OS X bundled Hiragino fonts into
+## TEXMFLOCAL/fonts/opentype/cjk-gs-integrate/
+lnsysfnt(){
+    local HRGNLEGACYDIR=$(kpsewhich -var-value=TEXMFLOCAL)/fonts/opentype/cjk-gs-integrate # screen/hiragino-legacy
+    local HRGNDIR=$(kpsewhich -var-value=TEXMFLOCAL)/fonts/truetype/cjk-gs-integrate # screen/hiragino
 
-mkdir -p ${HRGNDIR}
-pushd ${HRGNDIR}
-rm -f HiraginoSerif*.ttc HiraginoSans*.ttc
-case ${OSXVERSION} in
-    10.[0-9]|10.[0-9].*|10.10|10.10.*)
-        ## bundled Hiragino OpenType fonts (OS X 10.10 Yosemite or lower versions)
-        mkdir -p ${HRGNLEGACYDIR}
-        pushd ${HRGNLEGACYDIR}
-        rm -f HiraMin*.otf HiraKaku*.otf HiraMaru*.otf
+    mkdir -p ${HRGNDIR}
+    pushd ${HRGNDIR}
+    rm -f HiraginoSerif*.ttc HiraginoSans*.ttc
+    case ${OSXVERSION} in
+        10.[0-9]|10.[0-9].*|10.10|10.10.*)
+            ## bundled Hiragino OpenType fonts (OS X 10.10 Yosemite or lower versions)
+            mkdir -p ${HRGNLEGACYDIR}
+            pushd ${HRGNLEGACYDIR}
+            rm -f HiraMin*.otf HiraKaku*.otf HiraMaru*.otf
 
-        ln -s "/Library/Fonts/ヒラギノ明朝 Pro W3.otf" HiraMinPro-W3.otf
-        ln -s "/Library/Fonts/ヒラギノ明朝 Pro W6.otf" HiraMinPro-W6.otf
-        ln -s "/Library/Fonts/ヒラギノ丸ゴ Pro W4.otf" HiraMaruPro-W4.otf
-        ln -s "/Library/Fonts/ヒラギノ角ゴ Pro W3.otf" HiraKakuPro-W3.otf
-        ln -s "/Library/Fonts/ヒラギノ角ゴ Pro W6.otf" HiraKakuPro-W6.otf
-        ln -s "/Library/Fonts/ヒラギノ角ゴ Std W8.otf" HiraKakuStd-W8.otf
+            ln -s "/Library/Fonts/ヒラギノ明朝 Pro W3.otf" HiraMinPro-W3.otf
+            ln -s "/Library/Fonts/ヒラギノ明朝 Pro W6.otf" HiraMinPro-W6.otf
+            ln -s "/Library/Fonts/ヒラギノ丸ゴ Pro W4.otf" HiraMaruPro-W4.otf
+            ln -s "/Library/Fonts/ヒラギノ角ゴ Pro W3.otf" HiraKakuPro-W3.otf
+            ln -s "/Library/Fonts/ヒラギノ角ゴ Pro W6.otf" HiraKakuPro-W6.otf
+            ln -s "/Library/Fonts/ヒラギノ角ゴ Std W8.otf" HiraKakuStd-W8.otf
 
-        ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W3.otf" HiraMinProN-W3.otf
-        ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W6.otf" HiraMinProN-W6.otf
-        ln -s "/Library/Fonts/ヒラギノ丸ゴ ProN W4.otf"        HiraMaruProN-W4.otf
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴ ProN W3.otf" HiraKakuProN-W3.otf
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴ ProN W6.otf" HiraKakuProN-W6.otf
-        ln -s "/Library/Fonts/ヒラギノ角ゴ StdN W8.otf"        HiraKakuStdN-W8.otf
-        popd
+            ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W3.otf" HiraMinProN-W3.otf
+            ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W6.otf" HiraMinProN-W6.otf
+            ln -s "/Library/Fonts/ヒラギノ丸ゴ ProN W4.otf"        HiraMaruProN-W4.otf
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴ ProN W3.otf" HiraKakuProN-W3.otf
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴ ProN W6.otf" HiraKakuProN-W6.otf
+            ln -s "/Library/Fonts/ヒラギノ角ゴ StdN W8.otf"        HiraKakuStdN-W8.otf
+            popd
+            ;;
+        10.11|10.11.*|10.12|10.12.*)
+            ## bundled Hiragino OpenType fonts/collections (OS X 10.11 El Capitan/macOS 10.12 Sierra)
+            ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W3.ttc"  HiraginoSerif-W3.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W6.ttc"  HiraginoSerif-W6.ttc
+            ln -s "/Library/Fonts/ヒラギノ丸ゴ ProN W4.ttc"         HiraginoSansR-W4.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc" HiraginoSans-W3.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc" HiraginoSans-W6.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W8.ttc" HiraginoSans-W8.ttc
+
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W1.ttc" HiraginoSans-W1.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W2.ttc" HiraginoSans-W2.ttc
+
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W0.ttc" HiraginoSans-W0.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc" HiraginoSans-W4.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W5.ttc" HiraginoSans-W5.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W7.ttc" HiraginoSans-W7.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W9.ttc" HiraginoSans-W9.ttc
+            ;;
+        10.13|10.13.*)
+            ## bundled Hiragino OpenType fonts/collections (OS X 10.13 High Sierra)
+            ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc"     HiraginoSerif.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ丸ゴ ProN W4.ttc"  HiraginoSansR-W4.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W0.ttc" HiraginoSans-W0.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W1.ttc" HiraginoSans-W1.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W2.ttc" HiraginoSans-W2.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc" HiraginoSans-W3.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc" HiraginoSans-W4.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W5.ttc" HiraginoSans-W5.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc" HiraginoSans-W6.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W7.ttc" HiraginoSans-W7.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W8.ttc" HiraginoSans-W8.ttc
+            ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W9.ttc" HiraginoSans-W9.ttc
+            ;;
+        *)
+            echo E: not supported: ${OSXVERSION}
+            return 1
+            ;;
+    esac
+    popd
+    return 0
+}
+
+cjkgsintg(){
+    local cjkgsExtDB=
+    local cjkgsopts=
+
+    ## See cjk-gs-support/README-macos.md in details
+    case ${OSXVERSION} in
+        10.[0-9]|10.[0-9].*|10.10|10.10.*)
         ;;
-    10.11|10.11.*|10.12|10.12.*)
-        ## bundled Hiragino OpenType fonts/collections (OS X 10.11 El Capitan/macOS 10.12 Sierra)
-        ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W3.ttc"  HiraginoSerif-W3.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN W6.ttc"  HiraginoSerif-W6.ttc
-        ln -s "/Library/Fonts/ヒラギノ丸ゴ ProN W4.ttc"         HiraginoSansR-W4.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc" HiraginoSans-W3.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc" HiraginoSans-W6.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W8.ttc" HiraginoSans-W8.ttc
+        10.11|10.11.*)
+            cjkgsExtDB=elcapitan;;
+        10.12|10.12.*)
+            cjkgsExtDB=sierra;;
+        10.13|10.13.*)
+            cjkgsExtDB=highsierra;;
+        *)
+            echo E: not supported: ${OSXVERSION}
+            exit 1
+            ;;
+    esac
+    if [ -z "${cjkgsExtDB}" ]; then
+        cjkgsopts="--fontdef-add=${TLRESDIR}/cjk-gs-support/cjkgs-macos-${cjkgsExtDB}.dat"
+    fi
 
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W1.ttc" HiraginoSans-W1.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W2.ttc" HiraginoSans-W2.ttc
+    ${TLRESDIR}/cjk-gs-support/cjk-gs-integrate.pl --link-texmf ${cjkgsopts} || return 1
+    return 0
+}
 
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W0.ttc" HiraginoSans-W0.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc" HiraginoSans-W4.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W5.ttc" HiraginoSans-W5.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W7.ttc" HiraginoSans-W7.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W9.ttc" HiraginoSans-W9.ttc
-        ;;
-    10.13|10.13.*)
-        ## bundled Hiragino OpenType fonts/collections (OS X 10.13 High Sierra)
-        ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc"     HiraginoSerif.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ丸ゴ ProN W4.ttc"  HiraginoSansR-W4.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W0.ttc" HiraginoSans-W0.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W1.ttc" HiraginoSans-W1.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W2.ttc" HiraginoSans-W2.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc" HiraginoSans-W3.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc" HiraginoSans-W4.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W5.ttc" HiraginoSans-W5.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc" HiraginoSans-W6.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W7.ttc" HiraginoSans-W7.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W8.ttc" HiraginoSans-W8.ttc
-        ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W9.ttc" HiraginoSans-W9.ttc
-        ;;
-    *)
-        echo 
-        exit 
-        ;;
-esac
-popd
+## link Mac OS bundled fonts into TEXMFLOCAL/fonts/{open,true}type/cjk-gs-integrate/
+if [ ${with_cjkgssupport} -eq 1 }; then
+    cjkgsintg || exit 1
+else
+    lnsysfnt || exit 1
+fi
 
 ## set hiragino-<Mac OS X flavor>-pron
 kanjiEmbed=

--- a/Patch.sh
+++ b/Patch.sh
@@ -205,7 +205,7 @@ cjkgsintg(){
 }
 
 ## link Mac OS bundled fonts into TEXMFLOCAL/fonts/{open,true}type/cjk-gs-integrate/
-if [ ${with_cjkgssupport} -eq 1 }; then
+if [ ${with_cjkgssupport} -eq 1 ]; then
     cjkgsintg || exit 1
 else
     lnsysfnt || exit 1

--- a/patchapp.applescript
+++ b/patchapp.applescript
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 # SOFTWARE.
 
-set n to 150 -- 139 lines
+set n to 350 -- 304 /tmp/bibunsho7-patch.log
 set progress total steps to n
 set progress description to "Patch.app: 実行中..."
 set progress additional description to "待機中..."


### PR DESCRIPTION
自前のlnsysfnt.shに代えて、cjk-gs-supportを使うように変更。
ちなみに、改訂7版美文書作成入門書の付録DVDROMもMacインストーラー内でもcjk-gs-supportを使っている。

ゴニョゴニョしている環境があるかもしれないことを想定して、 `cjk-gs-integrate.pl --debug` 付きにしといた :-) 
