### PR TITLE
Fix for macOS 14 (Sonoma)

### DIFF
--- a/Patch.sh
+++ b/Patch.sh
@@ -161,7 +161,7 @@ lnsysfnt(){
             ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W7.ttc" HiraginoSans-W7.ttc
             ln -s "/System/Library/Fonts/ヒラギノ角ゴシック W9.ttc" HiraginoSans-W9.ttc
             ;;
-        10.1[3-6]|1[1-3].[0-9])
+        10.1[3-6]|1[1-4].[0-9])
             ## bundled Hiragino OpenType fonts/collections (OS X 10.13 High Sierra)
             ln -s "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc"     HiraginoSerif.ttc
             ln -s "/System/Library/Fonts/ヒラギノ丸ゴ ProN W4.ttc"  HiraginoSansR-W4.ttc
@@ -199,7 +199,7 @@ cjkgsintg(){
             cjkgsExtDB=elcapitan;;
         10.12)
             cjkgsExtDB=sierra;;
-        10.1[3-6]|1[1-3].[0-9])
+        10.1[3-6]|1[1-4].[0-9])
             cjkgsExtDB=highsierra;;
         *)
             echo E: not supported: ${OSXVERSION}


### PR DESCRIPTION
macOS 14 (Sonoma) にて `sudo ./Patch.sh` 実行時に
```
E: not supported: 14.3
```
と表示されて実行されない問題を修正しました。

動作確認した環境:
- macOS 14.3
- texlive-bin @2023.66589_4 (MacPorts)
- texlive-lang-japanese @66482_0 (MacPorts)